### PR TITLE
feat(shooting): add shooting, enemy spawn, projectile cleanup and damage (Block 5)

### DIFF
--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -1,38 +1,48 @@
 import type { Scene } from '@core/scene';
 import type { Game } from '@core/game';
-import { createWorld, makePlayer, makeEnemy } from '@state/world';
+import { createWorld, makePlayer } from '@state/world';
 import { inputSystem } from '@systems/input';
 import { movementSystem } from '@systems/movement';
+import { projectilesCleanupSystem } from '@systems/projectiles';
+import { createSpawnSystem } from '@systems/spawn';
 import { boundsSystem } from '@systems/bounds';
-import { collisionSystem } from '@systems/collision';
+import { damageSystem } from '@systems/damage';
 import { renderingSystem } from '@systems/rendering';
+import { createShootingSystem } from '@systems/shooting';
 
 export function createPlayScene(game: Game): Scene {
   const world = createWorld();
 
-  // Player
+  // Entities iniciales
   world.add(makePlayer());
 
-  // Enemy de prueba para validar colisiones
-  world.add(makeEnemy(300, 260));
+  // Systems con estado interno (spawn, shooting)
+  const spawnSystem = createSpawnSystem();
+  const shootingSystem = createShootingSystem();
+
+  // (Opcional) marcador local
+  let score = 0;
 
   return {
     update(dt) {
-      // 1) Input → actualiza kinematics del player
-      inputSystem(world, game);
-      // 2) Movement → aplica kinematics al transform
-      movementSystem(world, dt);
-      // 3) Bounds → mantiene entidades dentro del canvas
-      boundsSystem(world, game.ctx.canvas);
-      // 4) Collisions → detecta AABB (marca color de debug)
-      collisionSystem(world);
+      inputSystem(world, game);                         // teclado → kinematics
+      shootingSystem(world, game, dt);                 // genera balas (cooldown)
+      movementSystem(world, dt);                       // aplica kinematics
+      projectilesCleanupSystem(world, game.ctx.canvas);// limpia balas offscreen
+      spawnSystem(world, game, dt);                    // spawnea enemigos
+      boundsSystem(world, game.ctx.canvas);            // clamp entidades (no balas)
+      const before = world.entities.length;
+      damageSystem(world);                              // balas destruyen enemigos
+      const after = world.entities.length;
+      if (after < before) score += (before - after);    // demo: sumar por entidades removidas
     },
     render(ctx) {
-      // 5) Render → dibuja entidades
       renderingSystem(world, ctx);
-      ctx.fillStyle = '#0f0';
+      // HUD mínimo
+      ctx.fillStyle = '#fff';
       ctx.font = '14px monospace';
-      ctx.fillText('Block 4: bounds + collision (enemy dummy)', 16, 20);
+      ctx.fillText(`Score: ${score}`, 16, 20);
+      ctx.fillText(`Block 5: shooting + spawn + damage`, 16, 38);
     }
   };
 }

--- a/src/state/world.ts
+++ b/src/state/world.ts
@@ -48,3 +48,15 @@ export function makeEnemy(x = 300, y = 260) {
     sprite: { w: 28, h: 28, color: '#0af' }
   };
 }
+
+// --- Projectile factory ---
+export function makeProjectile(x: number, y: number, dir: 'right'|'left' = 'right') {
+  const speed = 360;
+  return {
+    tag: 'projectile' as const,
+    transform: { x, y },
+    kinematics: { vx: dir === 'right' ? speed : -speed, vy: 0, speed },
+    collider: { w: 8, h: 4, solid: false },
+    sprite: { w: 8, h: 4, color: '#fff' }
+  };
+}

--- a/src/systems/bounds.ts
+++ b/src/systems/bounds.ts
@@ -5,15 +5,12 @@ export function boundsSystem(world: World, canvas: HTMLCanvasElement) {
   const maxY = canvas.height;
 
   for (const e of world.entities) {
+    if (e.tag === 'projectile') continue; 
     if (!e.transform || !e.collider) continue;
 
     const { w, h } = e.collider;
-    const minX = 0;
-    const minY = 0;
-
-    // clamp AABB completo dentro del canvas
-    if (e.transform.x < minX) e.transform.x = minX;
-    if (e.transform.y < minY) e.transform.y = minY;
+    if (e.transform.x < 0) e.transform.x = 0;
+    if (e.transform.y < 0) e.transform.y = 0;
     if (e.transform.x + w > maxX) e.transform.x = maxX - w;
     if (e.transform.y + h > maxY) e.transform.y = maxY - h;
   }

--- a/src/systems/damage.ts
+++ b/src/systems/damage.ts
@@ -1,0 +1,20 @@
+import type { World } from '@state/world';
+import { aabbOverlap } from '@utils/aabb'; 
+
+export function damageSystem(world: World) {
+  const bullets = world.entities.filter(e => e.tag === 'projectile' && e.transform && e.collider);
+  const enemies = world.entities.filter(e => e.tag === 'enemy' && e.transform && e.collider);
+
+  for (const b of bullets) {
+    for (const en of enemies) {
+      const bt = b.transform!, bc = b.collider!;
+      const et = en.transform!, ec = en.collider!;
+      if (aabbOverlap(bt.x, bt.y, bc.w, bc.h, et.x, et.y, ec.w, ec.h)) {
+        // remove both
+        world.remove(b.id);
+        world.remove(en.id);
+        break; // bullet is gone; next bullet
+      }
+    }
+  }
+}

--- a/src/systems/projectiles.ts
+++ b/src/systems/projectiles.ts
@@ -1,0 +1,14 @@
+import type { World } from '@state/world';
+
+export function projectilesCleanupSystem(world: World, canvas: HTMLCanvasElement) {
+  const maxX = canvas.width;
+  const maxY = canvas.height;
+
+  for (const e of [...world.entities]) {
+    if (e.tag !== 'projectile' || !e.transform) continue;
+    const { x, y } = e.transform;
+    if (x < -32 || x > maxX + 32 || y < -32 || y > maxY + 32) {
+      world.remove(e.id);
+    }
+  }
+}

--- a/src/systems/shooting.ts
+++ b/src/systems/shooting.ts
@@ -1,0 +1,26 @@
+import type { World } from '@state/world';
+import type { Game } from '@core/game';
+import { makeProjectile } from '@state/world';
+
+export function createShootingSystem() {
+  let cooldown = 0;          // seconds remaining
+  const cadence = 0.25;      // shots per 0.25s
+
+  return function shootingSystem(world: World, game: Game, dt: number) {
+    // reduce cooldown
+    if (cooldown > 0) cooldown -= dt;
+
+    const fire = game.input.pressed(' ') || game.input.pressed('Enter');
+    if (!fire || cooldown > 0) return;
+
+    const player = world.entities.find(e => e.tag === 'player' && e.transform && e.sprite);
+    if (!player?.transform || !player.sprite) return;
+
+    // spawn from front of the player
+    const px = player.transform.x + (player.sprite.w ?? 16);
+    const py = player.transform.y + (player.sprite.h ?? 16) / 2;
+
+    world.add(makeProjectile(px, py - 2, 'right'));
+    cooldown = cadence;
+  };
+}

--- a/src/systems/spawn.ts
+++ b/src/systems/spawn.ts
@@ -1,0 +1,21 @@
+import type { World } from '@state/world';
+import type { Game } from '@core/game';
+import { makeEnemy } from '@state/world';
+
+export function createSpawnSystem() {
+  let t = 0;
+  const interval = 1.5; // seconds
+
+  return function spawnSystem(world: World, game: Game, dt: number) {
+    t += dt;
+    if (t < interval) return;
+    t = 0;
+
+    const { width, height } = game.ctx.canvas;
+    // spawn cerca del borde derecho, altura aleatoria
+    const x = Math.max(200, width - 80);
+    const y = Math.floor(60 + Math.random() * (height - 120));
+
+    world.add(makeEnemy(x, y));
+  };
+}

--- a/src/utils/aabb.ts
+++ b/src/utils/aabb.ts
@@ -1,0 +1,6 @@
+export function aabbOverlap(
+  ax: number, ay: number, aw: number, ah: number,
+  bx: number, by: number, bw: number, bh: number
+) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+}


### PR DESCRIPTION
### Summary
Introduces core gameplay loops: player shooting with cooldown, periodic enemy spawns, projectile cleanup, and projectile-vs-enemy damage.

### Main changes
- Added `shootingSystem` (Space/Enter, cooldown).
- Added `spawnSystem` (timed enemy spawns).
- Added `projectilesCleanupSystem` (off-screen removal).
- Added `damageSystem` (projectile vs enemy).
- Wired systems in Play scene.

### Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Player can shoot; enemies spawn periodically
- [x] Bullets removed off-screen; enemies destroyed on hit
