### PR TITLE
feat(ai): enemy seek behavior, player invulnerability and pause (Block 7)

### DIFF
--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -10,8 +10,9 @@ import { damageSystem } from '@systems/damage';
 import { renderingSystem } from '@systems/rendering';
 import { createShootingSystem } from '@systems/shooting';
 import { hudSystem } from '@systems/hud';
-import { checkGameOver } from '@systems/gameOverSystem';
+import { checkGameOver } from '@systems/gameOverSystem'; 
 import { playerHitSystem } from '@systems/playerHit';
+import { enemyAISystem } from '@systems/enemyAI';
 import { createGameOverScene } from './gameOverScene'; 
 
 export function createPlayScene(game: Game): Scene {
@@ -25,43 +26,97 @@ export function createPlayScene(game: Game): Scene {
   let score = 0;
   let lives = 3;
 
+  // ⏳ Invulnerabilidad
+  let invulnTimer = 0;       // segundos restantes
+  const invulnDuration = 1;  // 1s de i-frames
+
+  // ⏸️ Pausa (toggle con P)
+  let paused = false;
+  let prevP = false;
+
+  // Acumulador para el “flash” visual
+  let tAccum = 0;
+
+  function togglePauseIfNeeded() {
+    const p = game.input.pressed('p') || game.input.pressed('P');
+    if (p && !prevP) paused = !paused;
+    prevP = p;
+  }
+
+  function setPlayerTint(invulnerable: boolean) {
+    const player = world.entities.find(e => e.tag === 'player' && e.sprite);
+    if (!player || !player.sprite) return;
+    if (!invulnerable) {
+      player.sprite.color = '#ff0'; // color normal
+      return;
+    }
+    // parpadeo: alterna color con la “frecuencia” 10 Hz aprox
+    const blink = (Math.floor(tAccum * 10) % 2) === 0;
+    player.sprite.color = blink ? '#fff' : '#ff0';
+  }
+
   return {
     update(dt) {
+      // Toggle pausa
+      togglePauseIfNeeded();
+      if (paused) {
+        // aún así permitimos salir de pausa con P en frames siguientes
+        return;
+      }
+
+      tAccum += dt;
+      if (invulnTimer > 0) invulnTimer -= dt;
+
       inputSystem(world, game);
       shootingSystem(world, game, dt);
+
+      // 👇 IA enemigo calcula kinematics hacia el player
+      enemyAISystem(world);
+
       movementSystem(world, dt);
       projectilesCleanupSystem(world, game.ctx.canvas);
       spawnSystem(world, game, dt);
       boundsSystem(world, game.ctx.canvas);
 
-      // balas destruyen enemigos y suman score
+      // Balas vs enemigo → score
       const before = world.entities.length;
       damageSystem(world);
       const after = world.entities.length;
       if (after < before) score += before - after;
 
-      // player golpea enemigo → pierde vida
-      if (playerHitSystem(world)) {
+      // Player vs enemy → pierde vida (si no está invulnerable)
+      if (invulnTimer <= 0 && playerHitSystem(world)) {
         lives -= 1;
+        invulnTimer = invulnDuration;
         if (lives <= 0) {
           game.scenes.change(createGameOverScene(game, score));
-          return; // salimos para no seguir procesando este frame
+          return;
         }
-        // opcional: empuja un poco al player o pinta flash
-        // (de momento, sin knockback para mantenerlo simple)
       }
 
-      // condición adicional de game over (enemigo cruza borde)
-      if (checkGameOver(world, game.ctx.canvas)) {
+      // Regla adicional (si un enemigo sale del canvas, cuenta como daño)
+      if (invulnTimer <= 0 && checkGameOver(world, game.ctx.canvas)) {
         lives -= 1;
+        invulnTimer = invulnDuration;
         if (lives <= 0) {
           game.scenes.change(createGameOverScene(game, score));
         }
       }
     },
     render(ctx) {
+      // Tint del player según invulnerabilidad (parpadeo)
+      setPlayerTint(invulnTimer > 0);
+
       renderingSystem(world, ctx);
-      hudSystem(ctx, score, lives); // 👈 HUD sin 'game'
+      hudSystem(ctx, score, lives);
+
+      if (paused) {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        ctx.fillStyle = '#fff';
+        ctx.font = '22px monospace';
+        ctx.fillText('PAUSED (press P)', ctx.canvas.width / 2 - 120, ctx.canvas.height / 2);
+      }
     }
   };
 }

--- a/src/state/world.ts
+++ b/src/state/world.ts
@@ -39,15 +39,16 @@ export function makePlayer() {
 }
 
 // --- Enemy factory (dummy) ---
-export function makeEnemy(x = 300, y = 260) {
+export function makeEnemy(x = 300, y = 260, speed = 80) {
   return {
     tag: 'enemy' as const,
     transform: { x, y },
-    // sin kinematics por ahora (enemigo estático)
+    kinematics: { vx: 0, vy: 0, speed },     // 👈 velocidad base del enemigo
     collider: { w: 28, h: 28, solid: true },
     sprite: { w: 28, h: 28, color: '#0af' }
   };
 }
+
 
 // --- Projectile factory ---
 export function makeProjectile(x: number, y: number, dir: 'right'|'left' = 'right') {

--- a/src/systems/enemyAI.ts
+++ b/src/systems/enemyAI.ts
@@ -1,0 +1,33 @@
+import type { World } from '@state/world';
+
+// Normaliza un vector (dx, dy) y lo escala por "speed".
+function steer(dx: number, dy: number, speed: number) {
+  const len = Math.hypot(dx, dy) || 1;
+  return { vx: (dx / len) * speed, vy: (dy / len) * speed };
+}
+
+export function enemyAISystem(world: World) {
+  const player = world.entities.find(e => e.tag === 'player' && e.transform && e.kinematics);
+  if (!player?.transform) return;
+
+  for (const e of world.entities) {
+    if (e.tag !== 'enemy' || !e.transform) continue;
+
+    // si el enemigo no tiene kinematics, asume speed por defecto
+    const speed = e.kinematics?.speed ?? 80;
+
+    // objetivo: posición del jugador
+    const dx = player.transform.x - e.transform.x;
+    const dy = player.transform.y - e.transform.y;
+
+    const { vx, vy } = steer(dx, dy, speed);
+
+    // crea kinematics si no existe, o actualiza la existente
+    if (e.kinematics) {
+      e.kinematics.vx = vx;
+      e.kinematics.vy = vy;
+    } else {
+      e.kinematics = { vx, vy, speed };
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Adds enemy AI to seek the player, player invulnerability (i-frames with flashing) on hit, and pause toggle.

### Main changes
- Enemy AI system that steers enemies toward the player (kinematics-based).
- Player invulnerability cooldown after taking damage (visual flashing).
- Pause toggle (P) with overlay.
- Integrated AI + i-frames + pause into Play Scene.

### Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Enemies move toward the player
- [x] Player loses 1 life per contact (with i-frames)
- [x] Pause toggles with P
