### PR TITLE
refactor(core): typed update/render pipelines, PlayState orchestration, and score-on-kill system

### DIFF
--- a/src/scenes/play.state.ts
+++ b/src/scenes/play.state.ts
@@ -1,0 +1,48 @@
+import type { EventBus } from '@core/event-bus';
+import type { UIEvents } from '@ui/adapter';
+
+export type PlayState = {
+  score: number;
+  lives: number;
+  paused: boolean;
+  invulnTimer: number;
+  invulnDuration: number;
+  gameOver: boolean;
+};
+
+export function createPlayState() : PlayState {
+  return {
+    score: 0,
+    lives: 3,
+    paused: false,
+    invulnTimer: 0,
+    invulnDuration: 1,
+    gameOver: false,
+  };
+}
+
+export function syncUI(bus: EventBus<UIEvents>, s: PlayState) {
+  bus.emit('ui:score:set', s.score);
+  bus.emit('ui:lives:set', s.lives);
+  bus.emit('ui:paused:set', s.paused);
+}
+
+export function addScore(bus: EventBus<UIEvents>, s: PlayState, n: number) {
+  s.score += n;
+  bus.emit('ui:score:set', s.score);
+}
+
+export function togglePause(bus: EventBus<UIEvents>, s: PlayState) {
+  s.paused = !s.paused;
+  bus.emit('ui:paused:set', s.paused);
+}
+
+export function loseLife(bus: EventBus<UIEvents>, s: PlayState) {
+  s.lives = Math.max(0, s.lives - 1);
+  s.invulnTimer = s.invulnDuration;
+  bus.emit('ui:lives:set', s.lives);
+  if (s.lives <= 0) {
+    s.gameOver = true;
+    bus.emit('ui:paused:set', true);
+  }
+}

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -1,3 +1,4 @@
+// src/scenes/play.ts
 import type { Scene } from '@core/scene';
 import type { Game } from '@core/game';
 import type { EventBus } from '@core/event-bus';
@@ -20,21 +21,31 @@ export function createPlayScene(game: Game): Scene {
   const state = createPlayState();
   syncUI(g.bus, state);
 
- const updates = buildUpdatePipeline({ bus: g.bus, state });
+  // Update pipeline con contexto (ya recibe { bus, state } vía opts)
+  const updates = buildUpdatePipeline({ bus: g.bus, state });
 
-  const renders = buildRenderPipeline(world, g.ctx);
+  // Render pipeline con contexto (sin args; el ctx real se pasa al ejecutar)
+  const renders = buildRenderPipeline();
 
   let prevP = false;
 
   return {
     update(dt) {
       if (state.gameOver) return;
+
+      // Pausa (toggle con P)
       const p = g.input.pressed('p') || g.input.pressed('P');
       if (p && !prevP) togglePause(g.bus, state);
       prevP = p;
       if (state.paused) return;
+
+      // Timers (i-frames)
       state.invulnTimer = Math.max(0, state.invulnTimer - dt);
-      for (const step of updates) step({ dt, game: g, world });      
+
+      // Update pipeline
+      for (const step of updates) step({ dt, game: g, world });
+
+      // Player hits → pierde vida
       if (state.invulnTimer <= 0 && playerHitSystem(world)) {
         loseLife(g.bus, state);
         if (state.gameOver) {
@@ -43,6 +54,8 @@ export function createPlayScene(game: Game): Scene {
           return;
         }
       }
+
+      // Enemigo cruza borde izquierdo → también cuenta como daño
       if (state.invulnTimer <= 0 && checkGameOver(world, g.ctx.canvas)) {
         loseLife(g.bus, state);
         if (state.gameOver) {
@@ -53,7 +66,8 @@ export function createPlayScene(game: Game): Scene {
       }
     },
     render() {
-      for (const draw of renders) draw();
+      // Render pipeline con contexto
+      for (const draw of renders) draw({ game: g, world, ctx: g.ctx });
     }
   };
 }

--- a/src/scenes/play.ts
+++ b/src/scenes/play.ts
@@ -1,106 +1,59 @@
 import type { Scene } from '@core/scene';
 import type { Game } from '@core/game';
-import { createWorld, makePlayer } from '@state/world';
-import { inputSystem } from '@systems/input';
-import { movementSystem } from '@systems/movement';
-import { projectilesCleanupSystem } from '@systems/projectiles';
-import { createSpawnSystem } from '@systems/spawn';
-import { boundsSystem } from '@systems/bounds';
-import { damageSystem } from '@systems/damage';
-import { renderingSystem } from '@systems/rendering';
-import { createShootingSystem } from '@systems/shooting';
-import { checkGameOver } from '@systems/gameOverSystem';
-import { playerHitSystem } from '@systems/playerHit';
-import { enemyAISystem } from '@systems/enemyAI';
-import { createGameOverScene } from './gameOverScene'; 
-
 import type { EventBus } from '@core/event-bus';
 import type { UIEvents } from '@ui/adapter';
 
-// Game extendido con bus tipado (opcional)
-type GameWithBus = Game & { bus?: EventBus<UIEvents> };
+import { createWorld, makePlayer } from '@state/world';
+import { buildUpdatePipeline, buildRenderPipeline } from '@systems/index';
+import { createPlayState, syncUI, togglePause, loseLife } from './play.state';
+import { playerHitSystem } from '@systems/playerHit';
+import { checkGameOver } from '@systems/gameOverSystem';
+import { createGameOverScene } from './gameOverScene';
+
+type GameWithBus = Game & { bus: EventBus<UIEvents> };
 
 export function createPlayScene(game: Game): Scene {
-  const g = game as GameWithBus; // 👈 cast específico (sin any)
+  const g = game as GameWithBus;
   const world = createWorld();
-
   world.add(makePlayer());
 
-  const spawnSystem = createSpawnSystem();
-  const shootingSystem = createShootingSystem();
+  const state = createPlayState();
+  syncUI(g.bus, state);
 
-  let score = 0;
-  let lives = 3;
+ const updates = buildUpdatePipeline({ bus: g.bus, state });
 
-  let invulnTimer = 0;
-  const invulnDuration = 1;
+  const renders = buildRenderPipeline(world, g.ctx);
 
-  let paused = false;
   let prevP = false;
-  let gameOver = false;
-
-  // Inicializar UI
-  g.bus?.emit('ui:score:set', score);
-  g.bus?.emit('ui:lives:set', lives);
-  g.bus?.emit('ui:paused:set', paused);
-
-  function togglePauseIfNeeded() {
-    const p = game.input.pressed('p') || game.input.pressed('P');
-    if (p && !prevP) {
-      paused = !paused;
-      g.bus?.emit('ui:paused:set', paused);
-    }
-    prevP = p;
-  }
-
-  function loseLife() {
-    lives = Math.max(0, lives - 1);
-    g.bus?.emit('ui:lives:set', lives);
-    invulnTimer = invulnDuration;
-    if (lives <= 0) {
-      g.bus?.emit('ui:paused:set', true);
-      game.scenes.change(createGameOverScene(game, score));
-      gameOver = true;
-    }
-  }
 
   return {
     update(dt) {
-      if (gameOver) return;
-
-      togglePauseIfNeeded();
-      if (paused) return;
-
-      invulnTimer = Math.max(0, invulnTimer - dt);
-
-      inputSystem(world, game);
-      shootingSystem(world, game, dt);
-      enemyAISystem(world);
-
-      movementSystem(world, dt);
-      projectilesCleanupSystem(world, game.ctx.canvas);
-      spawnSystem(world, game, dt);
-      boundsSystem(world, game.ctx.canvas);
-
-      const before = world.entities.length;
-      damageSystem(world);
-      const after = world.entities.length;
-      if (after < before) {
-        score += before - after;
-        g.bus?.emit('ui:score:set', score);
+      if (state.gameOver) return;
+      const p = g.input.pressed('p') || g.input.pressed('P');
+      if (p && !prevP) togglePause(g.bus, state);
+      prevP = p;
+      if (state.paused) return;
+      state.invulnTimer = Math.max(0, state.invulnTimer - dt);
+      for (const step of updates) step({ dt, game: g, world });      
+      if (state.invulnTimer <= 0 && playerHitSystem(world)) {
+        loseLife(g.bus, state);
+        if (state.gameOver) {
+          g.bus.emit('ui:paused:set', true);
+          game.scenes.change(createGameOverScene(game, state.score));
+          return;
+        }
       }
-
-      if (invulnTimer <= 0 && playerHitSystem(world)) {
-        loseLife();
-        if (gameOver) return;
-      }
-      if (invulnTimer <= 0 && checkGameOver(world, game.ctx.canvas)) {
-        loseLife();
-        if (gameOver) return;
+      if (state.invulnTimer <= 0 && checkGameOver(world, g.ctx.canvas)) {
+        loseLife(g.bus, state);
+        if (state.gameOver) {
+          g.bus.emit('ui:paused:set', true);
+          game.scenes.change(createGameOverScene(game, state.score));
+          return;
+        }
       }
     },
-    render(ctx) {
-      renderingSystem(world, ctx);
+    render() {
+      for (const draw of renders) draw();
     }
   };
 }

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,0 +1,9 @@
+import type { World } from '@state/world';
+
+export function selectPlayer(world: World) {
+  return world.entities.find(e => e.tag === 'player' && e.transform && e.collider);
+}
+
+export function selectEnemies(world: World) {
+  return world.entities.filter(e => e.tag === 'enemy' && e.transform && e.collider);
+}

--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -1,3 +1,4 @@
+// src/systems/index.ts
 import type { Game } from '@core/game';
 import type { World } from '@state/world';
 
@@ -18,6 +19,9 @@ import type { PlayState } from '@scenes/play.state';
 
 export type UpdateCtx = { dt: number; game: Game; world: World };
 export type UpdateStep = (ctx: UpdateCtx) => void;
+
+export type RenderCtx = { game: Game; world: World; ctx: CanvasRenderingContext2D };
+export type RenderStep = (ctx: RenderCtx) => void;
 
 export function buildUpdatePipeline(
   opts?: { bus?: EventBus<UIEvents>; state?: PlayState }
@@ -42,6 +46,9 @@ export function buildUpdatePipeline(
   return steps;
 }
 
-export function buildRenderPipeline(world: World, ctx: CanvasRenderingContext2D) {
-  return [() => renderingSystem(world, ctx)];
+export function buildRenderPipeline(): RenderStep[] {
+  const steps: RenderStep[] = [
+    ({ world, ctx }) => renderingSystem(world, ctx),
+  ];
+  return steps;
 }

--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -1,0 +1,47 @@
+import type { Game } from '@core/game';
+import type { World } from '@state/world';
+
+import { inputSystem } from './input';
+import { enemyAISystem } from './enemyAI';
+import { movementSystem } from './movement';
+import { projectilesCleanupSystem } from './projectiles';
+import { boundsSystem } from './bounds';
+import { damageSystem } from './damage';
+import { renderingSystem } from './rendering';
+import { createShootingSystem } from './shooting';
+import { createSpawnSystem } from './spawn';
+import { createScoreOnKillSystem } from './score';
+
+import type { EventBus } from '@core/event-bus';
+import type { UIEvents } from '@ui/adapter';
+import type { PlayState } from '@scenes/play.state';
+
+export type UpdateCtx = { dt: number; game: Game; world: World };
+export type UpdateStep = (ctx: UpdateCtx) => void;
+
+export function buildUpdatePipeline(
+  opts?: { bus?: EventBus<UIEvents>; state?: PlayState }
+): UpdateStep[] {
+  const shootingSystem = createShootingSystem();
+  const spawnSystem = createSpawnSystem();
+  const scoreSystem =
+    opts?.bus && opts?.state ? createScoreOnKillSystem(opts.bus, opts.state) : null;
+
+  const steps: UpdateStep[] = [
+    ({ game, world }) => inputSystem(world, game),
+    ({ dt, game, world }) => shootingSystem(world, game, dt),
+    ({ world }) => enemyAISystem(world),
+    ({ dt, world }) => movementSystem(world, dt),
+    ({ game, world }) => projectilesCleanupSystem(world, game.ctx.canvas),
+    ({ dt, game, world }) => spawnSystem(world, game, dt),
+    ({ game, world }) => boundsSystem(world, game.ctx.canvas),
+    ({ world }) => damageSystem(world),
+    ({ world }) => { if (scoreSystem) scoreSystem(world); },
+  ];
+
+  return steps;
+}
+
+export function buildRenderPipeline(world: World, ctx: CanvasRenderingContext2D) {
+  return [() => renderingSystem(world, ctx)];
+}

--- a/src/systems/score.ts
+++ b/src/systems/score.ts
@@ -1,0 +1,25 @@
+import type { World } from '@state/world';
+import type { EventBus } from '@core/event-bus';
+import type { UIEvents } from '@ui/adapter';
+import type { PlayState } from '@scenes/play.state';
+import { addScore } from '@scenes/play.state';
+
+export function createScoreOnKillSystem(bus: EventBus<UIEvents>, state: PlayState) {
+  let prevEnemyIds = new Set<number>();
+  const awardedIds = new Set<number>();
+
+  return function scoreOnKillSystem(world: World) {
+    const currEnemyIds = new Set(
+      world.entities.filter(e => e.tag === 'enemy').map(e => e.id)
+    );
+
+    for (const id of prevEnemyIds) {
+      if (!currEnemyIds.has(id) && !awardedIds.has(id)) {
+        addScore(bus, state, 1);
+        awardedIds.add(id);
+      }
+    }
+
+    prevEnemyIds = currEnemyIds;
+  };
+}


### PR DESCRIPTION
### Summary
Consolidates architecture hardening across the game loop:
- Typed, context-based **Update** and **Render** pipelines.
- **PlayState** helpers for score/lives/pause with UI sync.
- **Score-on-kill** system that awards exactly once per removed enemy.
- Play scene acts as a thin orchestrator and triggers **Game Over** on zero lives.

### Main changes
- **Pipelines**
  - Introduced `UpdateCtx = { dt, game, world }` and `RenderCtx = { game, world, ctx }`.
  - Normalized steps to consume only what they need via destructuring.
  - Moved score logic into a dedicated system; removed ad-hoc score diffs from Play.
- **State**
  - `PlayState` with `syncUI`, `addScore`, `togglePause`, and `loseLife`.
  - Added world selectors (`selectPlayer`, `selectEnemies`) for future use.
- **Systems**
  - `score.ts`: score-on-kill system that counts removed enemies and awards once per enemy.
  - Integrated score system **after** `damageSystem` in update pipeline.
- **Scenes**
  - Play scene now executes pipelines with typed contexts and triggers `GameOverScene` when lives reach zero.

### Why
- Stronger typing and better scalability (context-based steps).
- Reduced coupling: Play focuses on orchestration; systems handle game logic.
- Correct scoring (no multi-awards per enemy due to multiple bullets).

### Technical notes
- Update pipeline: `for (const step of updates) step({ dt, game, world });`
- Render pipeline: `for (const draw of renders) draw({ game, world, ctx });`
- Score system uses internal `prevEnemyIds` + `awardedIds` to ensure exact-once awarding.

### Breaking changes
- `buildUpdatePipeline` no longer takes `(game, world)`; it now accepts only `{ bus, state }` options and returns an array of `UpdateStep`.
- `buildRenderPipeline()` returns an array of `RenderStep` without parameters; render context is passed on execution.

### Verification
- `npm run typecheck` passes
- `npm run lint` passes
- Game runs; pause with `P`
- Score increments **+1 per enemy** (no duplicates)
- Game Over triggers when lives reach 0 and scene changes to `GameOverScene`

### Checklist
- [x] Context-based Update and Render pipelines
- [x] Score-on-kill system wired after `damageSystem`
- [x] PlayState with UI synchronization
- [x] Game Over scene transition preserved
- [x] No unused parameters in TypeScript (`TS6133`)

### Commits included
- feat(state): add world selectors (player and enemies)
- feat(scene): introduce PlayState with UI sync, addScore, togglePause and loseLife
- feat(systems): add score-on-kill system awarding once per removed enemy
- refactor(pipeline): use typed UpdateCtx and integrate score-on-kill after damage
- refactor(scene): orchestrate update pipeline with ctx and trigger Game Over on zero lives
- refactor(pipeline): introduce RenderCtx and context-based render pipeline
- refactor(scene): call render pipeline with typed RenderCtx {game, world, ctx}
